### PR TITLE
Added the Settings Panel

### DIFF
--- a/src/main/java/app/controller/settings/SettingsGenerator.java
+++ b/src/main/java/app/controller/settings/SettingsGenerator.java
@@ -8,12 +8,16 @@ public abstract class SettingsGenerator
     public static Settings mockSettings()
     {
         Settings settings = new Settings();
-        settings.setHeight(400);
-        settings.setWidth(300);
-        settings.addFurniture(new Rectangle2D(10, 10, 10, 10), FurnitureType.WALL);
-        settings.addFurniture(new Rectangle2D(30, 10, 10, 10), FurnitureType.GLASS);
-        settings.addFurniture(new Rectangle2D(10, 30, 10, 10), FurnitureType.TARGET);
-        settings.addFurniture(new Rectangle2D(30, 30, 10, 10), FurnitureType.TOWER);
+        settings.setName("best_map");
+        settings.setGameMode(1);
+        settings.setTimeStep(0.5);
+        settings.setScaling(0.1);
+        settings.setNoOfGuards(3);
+        settings.setNoOfIntruders(5);
+        settings.setWalkSpeedGuard(13.5);
+        settings.setWalkSpeedIntruder(15.0);
+        settings.setSprintSpeedGuard(21.5);
+        settings.setSprintSpeedIntruder(23);
         return settings;
     }
 

--- a/src/main/java/app/view/mapBuilder/FurniturePane.java
+++ b/src/main/java/app/view/mapBuilder/FurniturePane.java
@@ -55,12 +55,6 @@ public class FurniturePane extends StackPane
 
         vbox.getChildren().addAll(teleport, x, y);
 
-        // Spawn areas
-        Label spawns = new Label("Spwan Areas:");
-        Button aSpawn = new Button("Agent Spawn Area");
-        Button iSpawn = new Button("Intruder Spawn Area");
-        vbox.getChildren().addAll(spawns, aSpawn, iSpawn);
-
         // Furniture type enums
         Label furniture = new Label("Furniture Items:");
         vbox.getChildren().add(furniture);

--- a/src/main/java/app/view/mapBuilder/SettingsPane.java
+++ b/src/main/java/app/view/mapBuilder/SettingsPane.java
@@ -1,17 +1,51 @@
 package app.view.mapBuilder;
 
+import app.controller.settings.Settings;
+import javafx.geometry.Insets;
 import javafx.scene.control.Label;
 import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
+import javafx.scene.text.Font;
+import javafx.scene.text.FontWeight;
 
 public class SettingsPane extends StackPane // Might need to change this to extend something else
 {
     private StartMenu startMenu;
+    private Settings s;
 
-    public SettingsPane(StartMenu startMenu)
+    public SettingsPane(StartMenu startMenu, Settings s)
     {
         this.startMenu = startMenu;
+        this.s = s;
 
-        Label label = new Label("Settings Go Here");
-        this.getChildren().add(label);
+        // Labels displaying current settings information.
+        VBox vbox = new VBox(10);
+        Label header = new Label("Current simulation settings:");
+        header.setFont(Font.font("", FontWeight.BOLD, 24));
+        Label mapName = new Label("Map Name - " + s.getName());
+        mapName.setFont(new Font(16));
+        Label gameMode = new Label("Game Mode - " + s.getGameMode());
+        gameMode.setFont(new Font(16));
+        Label timeStep = new Label("Time Step - " + s.getTimeStep());
+        timeStep.setFont(new Font(16));
+        Label scaling = new Label("Scaling - " + s.getScaling());
+        scaling.setFont(new Font(16));
+        Label noOfGuards = new Label("Number of Guards - " + s.getNoOfGuards());
+        noOfGuards.setFont(new Font(16));
+        Label noOfIntruders = new Label("Number of Intruders - " + s.getNoOfIntruders());
+        noOfIntruders.setFont(new Font(16));
+        Label baseGuard = new Label("Walk speed Guard - " + s.getWalkSpeedGuard());
+        baseGuard.setFont(new Font(16));
+        Label baseIntruder = new Label("Walk speed Intruder - " + s.getWalkSpeedIntruder());
+        baseIntruder.setFont(new Font(16));
+        Label sprintGuard = new Label("Sprint speed Guard - " + s.getSprintSpeedGuard());
+        sprintGuard.setFont(new Font(16));
+        Label sprintIntruder = new Label("Sprint speed Intruder - " + s.getSprintSpeedIntruder());
+        sprintIntruder.setFont(new Font(16));
+        vbox.getChildren().addAll(  header, mapName, gameMode, timeStep, scaling, noOfGuards,
+                                    noOfIntruders, baseGuard, baseIntruder, sprintGuard,
+                                    sprintIntruder);
+        this.setMargin(vbox, new Insets(10, 10, 10, 10));
+        this.getChildren().addAll(vbox);
     }
 }

--- a/src/main/java/app/view/mapBuilder/SettingsPane.java
+++ b/src/main/java/app/view/mapBuilder/SettingsPane.java
@@ -3,6 +3,8 @@ package app.view.mapBuilder;
 import app.controller.settings.Settings;
 import javafx.geometry.Insets;
 import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.GridPane;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Font;
@@ -20,31 +22,81 @@ public class SettingsPane extends StackPane // Might need to change this to exte
 
         // Labels displaying current settings information.
         VBox vbox = new VBox(10);
-        Label header = new Label("Current simulation settings:");
+        Label header = new Label("Settings:");
         header.setFont(Font.font("", FontWeight.BOLD, 24));
-        Label mapName = new Label("Map Name - " + s.getName());
+
+        // Grid layout
+        GridPane grid = new GridPane();
+        grid.setVgap(10);
+        grid.setHgap(10);
+
+        // Labels
+        Label mapName = new Label("Map Name:");
         mapName.setFont(new Font(16));
-        Label gameMode = new Label("Game Mode - " + s.getGameMode());
+        Label gameMode = new Label("Game Mode:");
         gameMode.setFont(new Font(16));
-        Label timeStep = new Label("Time Step - " + s.getTimeStep());
+        Label timeStep = new Label("Time Step:");
         timeStep.setFont(new Font(16));
-        Label scaling = new Label("Scaling - " + s.getScaling());
+        Label scaling = new Label("Scaling:");
         scaling.setFont(new Font(16));
-        Label noOfGuards = new Label("Number of Guards - " + s.getNoOfGuards());
+        Label noOfGuards = new Label("Number of Guards:");
         noOfGuards.setFont(new Font(16));
-        Label noOfIntruders = new Label("Number of Intruders - " + s.getNoOfIntruders());
+        Label noOfIntruders = new Label("Number of Intruders:");
         noOfIntruders.setFont(new Font(16));
-        Label baseGuard = new Label("Walk speed Guard - " + s.getWalkSpeedGuard());
+        Label baseGuard = new Label("Walk speed Guard:");
         baseGuard.setFont(new Font(16));
-        Label baseIntruder = new Label("Walk speed Intruder - " + s.getWalkSpeedIntruder());
+        Label baseIntruder = new Label("Walk speed Intruder:");
         baseIntruder.setFont(new Font(16));
-        Label sprintGuard = new Label("Sprint speed Guard - " + s.getSprintSpeedGuard());
+        Label sprintGuard = new Label("Sprint speed Guard:");
         sprintGuard.setFont(new Font(16));
-        Label sprintIntruder = new Label("Sprint speed Intruder - " + s.getSprintSpeedIntruder());
+        Label sprintIntruder = new Label("Sprint speed Intruder:");
         sprintIntruder.setFont(new Font(16));
-        vbox.getChildren().addAll(  header, mapName, gameMode, timeStep, scaling, noOfGuards,
-                                    noOfIntruders, baseGuard, baseIntruder, sprintGuard,
-                                    sprintIntruder);
+
+        // Text Fields with current values editable.
+        TextField name = new TextField();
+        name.setText(s.getName());
+        TextField mode = new TextField();
+        mode.setText(""+s.getGameMode());
+        TextField step = new TextField();
+        step.setText(""+s.getTimeStep());
+        TextField scale = new TextField();
+        scale.setText(""+s.getScaling());
+        TextField noGuards = new TextField();
+        noGuards.setText(""+s.getNoOfGuards());
+        TextField noIntruders = new TextField();
+        noIntruders.setText(""+s.getNoOfIntruders());
+        TextField bGuard = new TextField();
+        bGuard.setText(""+s.getWalkSpeedGuard());
+        TextField bIntruder = new TextField();
+        bIntruder.setText(""+s.getWalkSpeedIntruder());
+        TextField sGuard = new TextField();
+        sGuard.setText(""+s.getSprintSpeedGuard());
+        TextField sIntruder = new TextField();
+        sIntruder.setText(""+s.getSprintSpeedIntruder());
+
+        // Add labels and fields to grid
+        grid.add(mapName, 0, 0);
+        grid.add(name, 1, 0);
+        grid.add(gameMode, 0, 1);
+        grid.add(mode, 1, 1);
+        grid.add(timeStep, 0, 2);
+        grid.add(step, 1, 2);
+        grid.add(scaling, 0, 3);
+        grid.add(scale, 1, 3);
+        grid.add(noOfGuards, 0, 4);
+        grid.add(noGuards, 1, 4);
+        grid.add(noOfIntruders, 0, 5);
+        grid.add(noIntruders, 1, 5);
+        grid.add(baseGuard, 0, 6);
+        grid.add(bGuard, 1, 6);
+        grid.add(baseIntruder, 0, 7);
+        grid.add(bIntruder, 1, 7);
+        grid.add(sprintGuard, 0, 8);
+        grid.add(sGuard, 1, 8);
+        grid.add(sprintIntruder, 0, 9);
+        grid.add(sIntruder, 1, 9);
+
+        vbox.getChildren().addAll(header, grid);
         this.setMargin(vbox, new Insets(10, 10, 10, 10));
         this.getChildren().addAll(vbox);
     }

--- a/src/main/java/app/view/mapBuilder/StartMenu.java
+++ b/src/main/java/app/view/mapBuilder/StartMenu.java
@@ -1,6 +1,7 @@
 package app.view.mapBuilder;
 
 import app.App;
+import app.controller.settings.SettingsGenerator;
 import app.view.FileMenuBar;
 import javafx.scene.layout.BorderPane;
 import lombok.Getter;
@@ -15,7 +16,7 @@ public class StartMenu extends BorderPane
         this.setTop(new FileMenuBar(app));
         MapBuilder mb = new MapBuilder(this);
         this.setLeft(new FurniturePane(this, mb));
-        this.setRight(new SettingsPane(this));
+        this.setRight(new SettingsPane(this, SettingsGenerator.mockSettings()));
         this.setCenter(mb);
     }
 }


### PR DESCRIPTION
SeTtings Panel displays the parameters of the settings object loaded via constructor.

Start Menu changed to create mock settings to display.

Removed unnecessary duplication of buttons from furniture panel.

Mock settings method in settings generator changed to test the workings of the settings panel.

Below where the current settings are displayed, text fields for the same variables could be added to collect the new parameters for these settings on the new map.

Closes #92 