### PR TITLE
Draw border

### DIFF
--- a/src/main/java/app/controller/settings/SettingsGenerator.java
+++ b/src/main/java/app/controller/settings/SettingsGenerator.java
@@ -10,8 +10,8 @@ public abstract class SettingsGenerator
         Settings settings = new Settings();
         settings.setName("best_map");
         settings.setGameMode(1);
-        settings.setTimeStep(0.5);
-        settings.setScaling(0.1);
+        settings.setWidth(1200);
+        settings.setHeight(600);
         settings.setNoOfGuards(3);
         settings.setNoOfIntruders(5);
         settings.setWalkSpeedGuard(13.5);

--- a/src/main/java/app/controller/settings/SettingsGenerator.java
+++ b/src/main/java/app/controller/settings/SettingsGenerator.java
@@ -10,7 +10,7 @@ public abstract class SettingsGenerator
         Settings settings = new Settings();
         settings.setName("best_map");
         settings.setGameMode(1);
-        settings.setWidth(1200);
+        settings.setWidth(800);
         settings.setHeight(600);
         settings.setNoOfGuards(3);
         settings.setNoOfIntruders(5);

--- a/src/main/java/app/view/mapBuilder/DisplayPane.java
+++ b/src/main/java/app/view/mapBuilder/DisplayPane.java
@@ -51,7 +51,8 @@ public class DisplayPane extends Canvas
 
         // Draw map boundary
         gc.setStroke(Color.BLACK);
-        gc.strokeRect(0, 0, startMenu.getMapWidth(), startMenu.getMapHeight());
+        gc.setLineWidth(3.0);
+        gc.strokeRect(3, 3, startMenu.getMapWidth(), startMenu.getMapHeight());
 
         vLines.forEach(e -> e.draw(gc));
         hLines.forEach(e -> e.draw(gc));

--- a/src/main/java/app/view/mapBuilder/DisplayPane.java
+++ b/src/main/java/app/view/mapBuilder/DisplayPane.java
@@ -37,6 +37,10 @@ public class DisplayPane extends Canvas
         gc.setFill(backgroundColour);
         gc.fillRect(0, 0, getWidth(), getHeight());
 
+        // Draw map boundary
+        gc.setStroke(Color.BLACK);
+        gc.strokeRect(0, 0, startMenu.getMapWidth(), startMenu.getMapHeight());
+
         objects.forEach(e -> e.draw(gc));
 
 

--- a/src/main/java/app/view/mapBuilder/SettingsPane.java
+++ b/src/main/java/app/view/mapBuilder/SettingsPane.java
@@ -117,6 +117,16 @@ public class SettingsPane extends StackPane
         this.getChildren().addAll(vbox);
     }
 
+    public int getMapWidth()
+    {
+        return Integer.parseInt(w.getText());
+    }
+
+    public int getMapHeight()
+    {
+        return Integer.parseInt(h.getText());
+    }
+
     public void getSettings()
     {
         s.setName(name.getText());

--- a/src/main/java/app/view/mapBuilder/StartMenu.java
+++ b/src/main/java/app/view/mapBuilder/StartMenu.java
@@ -21,9 +21,9 @@ public class StartMenu extends BorderPane
     {
         this.app = app;
         settings = SettingsGenerator.mockSettings();
-        displayPane = new DisplayPane(this);
-        settingsPane = new SettingsPane(this, settings);
         furniturePane = new FurniturePane(this, displayPane);
+        settingsPane = new SettingsPane(this, settings);
+        displayPane = new DisplayPane(this);
 
         this.setTop(new FileMenuBar(app));
         this.setLeft(furniturePane);

--- a/src/main/java/app/view/mapBuilder/StartMenu.java
+++ b/src/main/java/app/view/mapBuilder/StartMenu.java
@@ -31,6 +31,16 @@ public class StartMenu extends BorderPane
         this.setCenter(displayPane);
     }
 
+    public int getMapWidth()
+    {
+        return settingsPane.getMapWidth();
+    }
+
+    public int getMapHeight()
+    {
+        return settingsPane.getMapHeight();
+    }
+
     public void saveSettings()
     {
         furniturePane.getSettings(settings);

--- a/src/main/java/app/view/simulation/Renderer.java
+++ b/src/main/java/app/view/simulation/Renderer.java
@@ -38,6 +38,11 @@ public class Renderer extends Canvas
         GraphicsContext gc = this.getGraphicsContext2D();
         drawBackground(gc);
 
+        // Draw map boundary
+        gc.setStroke(Color.BLACK);
+        gc.setLineWidth(3.0);
+        gc.strokeRect(3, 3, map.getSettings().getWidth(), map.getSettings().getHeight());
+
         map.drawIntruderSpawn(gc);
         map.drawGuardSpawn(gc);
         map.getFurniture().forEach(e -> e.draw(gc));


### PR DESCRIPTION
Uses the Height and Width in settings panel to draw the outer boundary of the map. It is not a boundary object. So agents can still move over it currently. For the simulation, height and width are taken from the settings object.

Closes #142 