### PR TITLE
Agent State Change

### DIFF
--- a/src/main/java/app/controller/GameEngine.java
+++ b/src/main/java/app/controller/GameEngine.java
@@ -42,6 +42,7 @@ public class GameEngine
         map.getAgents().forEach(a -> a.getView().forEach(ray -> a.updateSeen(ray.getV())));
         map.getAgents().forEach(a -> map.updateAllSeen(a));
         map.getAgents().forEach(a -> map.checkForCapture(a));
+        map.updateStates();
 
         for (Agent a : map.getAgents())
         {

--- a/src/main/java/app/model/Map.java
+++ b/src/main/java/app/model/Map.java
@@ -210,6 +210,16 @@ public class Map
         }
     }
 
+    public void updateStates()
+    {
+        ArrayList<Agent> new_states = new ArrayList<>();
+        for(Agent a: agents)
+        {
+            new_states.add(a.nextState());
+        }
+        agents = new_states;
+    }
+
     public void deleteAgent(Agent agent)
     {
         deletion.push(agent);

--- a/src/main/java/app/model/agents/Agent.java
+++ b/src/main/java/app/model/agents/Agent.java
@@ -47,4 +47,6 @@ public interface Agent extends Boundary
     Team getTeam();
 
     void setTgtDirection(Vector tgtDirection);
+
+    Agent nextState();
 }

--- a/src/main/java/app/model/agents/Agent.java
+++ b/src/main/java/app/model/agents/Agent.java
@@ -48,5 +48,9 @@ public interface Agent extends Boundary
 
     void setTgtDirection(Vector tgtDirection);
 
+    Vector getTgtDirection();
+
     Agent nextState();
+
+    AgentView getAgentViewWindow();
 }

--- a/src/main/java/app/model/agents/AgentImp.java
+++ b/src/main/java/app/model/agents/AgentImp.java
@@ -143,4 +143,10 @@ public class AgentImp implements Agent
     {
         agentViewWindow = agentView;
     }
+
+    @Override
+    public Agent nextState()
+    {
+        return this;
+    }
 }

--- a/src/main/java/app/model/agents/AgentImp.java
+++ b/src/main/java/app/model/agents/AgentImp.java
@@ -23,13 +23,13 @@ public class AgentImp implements Agent
     @Getter @Setter protected double maxSprint = 10;
     @Getter @Setter protected Vector direction;
     @Getter @Setter protected boolean moveFailed;
-    @Setter protected Vector tgtDirection;
+    @Getter @Setter protected Vector tgtDirection;
     @Getter protected Team team;
     @Getter protected Vector position;
     @Getter protected double radius;
     @Getter protected ArrayList<Ray> view;
     @Getter protected VectorSet seen;
-    protected AgentView agentViewWindow;
+    @Getter protected AgentView agentViewWindow;
 
     @Getter protected static MemoryGraph<GraphCell, DefaultEdge> world;
 
@@ -53,6 +53,21 @@ public class AgentImp implements Agent
         this.tgtDirection = tgtDirection;
         view = new ArrayList<>();
         seen = new VectorSet();
+    }
+
+    public AgentImp(Agent other)
+    {
+        this.direction = other.getDirection();
+        this.position = other.getPosition();
+        this.radius = other.getRadius();
+        this.team = other.getTeam();
+        this.tgtDirection = other.getTgtDirection();
+        this.view = other.getView();
+        this.seen = other.getSeen();
+        this.maxSprint = other.getMaxSprint();
+        this.maxWalk = other.getMaxWalk();
+        this.agentViewWindow = other.getAgentViewWindow();
+        // TODO add hearing after SoundEngine refactor merged
     }
 
     @Override


### PR DESCRIPTION
closes #253 Agent State Change

Adds a `nextState` method to the agent, which should be used to set the conditions for which an agent will change into another agent, the default action should always be to return `this` in the case of no change of state.  The default implementation in `AgentImp` is as follows:

```java
    @Override
    public Agent nextState()
    {
        return this;
    }
```

This can be extended using other methods built in to the super class, or written specifically for the agent you are working on:

```java
    @Override
    public Agent nextState()
    {
        if(enemyAgentSeen())
            return new FighterAgent(position, direction, radius, team);
        
        return this;
    }
```    