### PR TITLE
patches bug #293

### DIFF
--- a/src/main/java/app/controller/linAlg/Intersection.java
+++ b/src/main/java/app/controller/linAlg/Intersection.java
@@ -165,8 +165,16 @@ public abstract class Intersection
         return findIntersection(r1, r2) != null;
     }
 
+    public static boolean hasLimitedIntersection(Ray ray, Vector center, double radius)
+    {
+        return hasLimitedIntersection(ray.getU(), ray.getV(), center, radius);
+    }
+
     public static boolean hasLimitedIntersection(Vector A, Vector B, Vector center, double radius)
     {
+        if(A.dist(center) <= radius || B.dist(center) <= radius)
+            return true;
+
         double baX = B.getX() - A.getX();
         double baY = B.getY() - A.getY();
         double caX = center.getX() - A.getX();
@@ -191,11 +199,6 @@ public abstract class Intersection
             return false;
     }
 
-    public static boolean hasLimitedIntersection(Ray ray, Vector center, double radius)
-    {
-        return hasLimitedIntersection(ray.getU(), ray.getV(), center, radius);
-    }
-
     public static boolean hasDirectionIntersect(Vector start,
                                                 Vector end,
                                                 double radius,
@@ -216,7 +219,8 @@ public abstract class Intersection
         if(otherRotate.getX() >= recBL_rotate.getX() &&
                 otherRotate.getX() <= recTR_rotate.getX() &&
                 otherRotate.getY() >= recBL_rotate.getY() &&
-                otherRotate.getY() <= recTR_rotate.getY()){
+                otherRotate.getY() <= recTR_rotate.getY())
+        {
             return true;
         }
 

--- a/src/main/java/app/controller/soundEngine/SoundEngine.java
+++ b/src/main/java/app/controller/soundEngine/SoundEngine.java
@@ -37,7 +37,7 @@ public class SoundEngine
                 endPoint = bdyIntersection;
 
 
-            if(r.getBounces() > 0)
+            if(r.getBounces() > 0 && endPoint.dist(r.getU()) > 0.01)
             {
                 Vector new_origin = bouncePoint(endPoint, r.getU());
                 stack.addAll(SoundRayScatter.angle360(new_origin, noOfRays, maxDist, r.getBounces()));

--- a/src/main/java/app/model/Map.java
+++ b/src/main/java/app/model/Map.java
@@ -24,7 +24,7 @@ import java.util.Stack;
 
 public class Map
 {
-    @Setter private final Boolean HUMAN_ACTIVE = true;
+    @Setter private Boolean HUMAN_ACTIVE = true;
     @Getter private ArrayList<Furniture> furniture;
     @Getter private ArrayList<Agent> agents;
     @Getter private ArrayList<SoundSource> soundSources;
@@ -88,7 +88,7 @@ public class Map
 
         if (HUMAN_ACTIVE)
         {
-            Vector humanStart = new Vector(100,100);
+            Vector humanStart = new Vector(100,100);    // Do not change this, it will break tests!
             human = new Human(humanStart, new Vector(1, 0), 10, Type.INTRUDER);
             human.setMaxWalk(settings.getWalkSpeedGuard());
             human.setMaxSprint(settings.getSprintSpeedGuard());
@@ -222,7 +222,7 @@ public class Map
 
     /**
      * @param v: a vector in R^2 on the map
-     * @returns Type: an enum of the team of the agent or furniture at Vector v,
+     * @return Type: an enum of the team of the agent or furniture at Vector v,
      * returns null if nothing is found.
      */
     public Type objectAt(Vector v)


### PR DESCRIPTION
Closes #293: bug was caused by the sound engine trying to stochastically bounce sound rays from just short of the line that represents the boundary/agent (this is required to stop sound rays becoming trapped within the interior of walls accidentally). The minuscule distance between the agent and the sound ray caused issues as the vector created held NaN values that then spawned their own NaN children in a markov chain.

Patched with a distance check that should have minimal impact on performance and is unlikely to be actioned in all but the rarest cases.