### PR TITLE
#316 Fixed. One line change.

### DIFF
--- a/src/main/java/app/view/mapBuilder/SettingsPane.java
+++ b/src/main/java/app/view/mapBuilder/SettingsPane.java
@@ -153,7 +153,7 @@ public class SettingsPane extends StackPane
         settings.setWalkSpeedGuard(Double.parseDouble(bGuard.getText()));
         settings.setWalkSpeedIntruder(Double.parseDouble(bIntruder.getText()));
         settings.setSprintSpeedGuard(Double.parseDouble(sGuard.getText()));
-        settings.setWalkSpeedIntruder(Double.parseDouble(sIntruder.getText()));
+        settings.setSprintSpeedIntruder(Double.parseDouble(sIntruder.getText()));
         return settings;
     }
 }


### PR DESCRIPTION
Fixed small typo in settings pane. Now the intruders walk and sprint speed get saved correctly when creating a map. 

Closes #316 