### PR TITLE
#329 Capture Occurred Detection

### DIFF
--- a/src/main/java/app/model/Map.java
+++ b/src/main/java/app/model/Map.java
@@ -186,6 +186,7 @@ public class Map
 
     public void checkForCapture(Agent currentAgent)
     {
+        boolean flag = false;
         if(currentAgent.getType() != Type.GUARD)
             return;
 
@@ -196,10 +197,15 @@ public class Map
                 double dist = currentAgent.getPosition().dist(otherAgent.getPosition());
                 if(dist <= (currentAgent.getRadius() + otherAgent.getRadius() + 3))
                 {
+                    flag = true;
                     deleteAgent(otherAgent);
+                    currentAgent.setCaptureOccurred(true);
                 }
             }
         }
+
+        if(!flag)
+            currentAgent.setCaptureOccurred(false);
     }
 
 

--- a/src/main/java/app/model/agents/Agent.java
+++ b/src/main/java/app/model/agents/Agent.java
@@ -48,6 +48,8 @@ public interface Agent extends Boundary
 
     void setMoveFailed(boolean failed);
 
+    void setCaptureOccurred(boolean occurred);
+
     void updateSeen(Vector vector);
 
     void addViewWindow(AgentView agentView);

--- a/src/main/java/app/model/agents/AgentImp.java
+++ b/src/main/java/app/model/agents/AgentImp.java
@@ -24,6 +24,7 @@ public class AgentImp implements Agent
     @Getter @Setter protected double moveLength = 20;
     @Getter @Setter protected Vector direction;
     @Getter @Setter protected boolean moveFailed;
+    @Getter @Setter protected boolean captureOccurred;
     @Getter @Setter protected Vector tgtDirection;
     @Getter protected Type type;
     @Getter protected Vector position;


### PR DESCRIPTION
Adds captureOccurred boolean to AgentImp which is set true if a capture occurred during the previous move and false if not. Boolean required in Capture agent as a state change condition. 

Closes #329 