### PR TITLE
#338 File name chosen by user when creating map

### DIFF
--- a/src/main/java/app/view/Alert.java
+++ b/src/main/java/app/view/Alert.java
@@ -5,6 +5,7 @@ import javafx.geometry.Pos;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.stage.Modality;
@@ -13,6 +14,8 @@ import javafx.stage.Stage;
 public class Alert
 {
     static boolean response;
+    static String answer;
+    static TextField userAnswer;
 
     public static void displayAlert(String title, String message)
     {
@@ -68,6 +71,36 @@ public class Alert
         return response;
     }
 
+    public static String answerAlert(String title, String message)
+    {
+        Stage window = new Stage();
+
+        window.initModality(Modality.APPLICATION_MODAL);
+        window.setTitle(title);
+        window.setMinWidth(500);
+
+        Label lbl = new Label();
+        lbl.setText(message);
+
+        userAnswer = new TextField();
+        Button cancelButton = new Button("Save");
+        cancelButton.setOnAction(e -> handleSave(window));
+
+        HBox hLayout = new HBox(25);
+        hLayout.getChildren().addAll(userAnswer, cancelButton);
+        hLayout.setAlignment(Pos.CENTER);
+        VBox layout = new VBox(10);
+        layout.getChildren().addAll(lbl, hLayout);
+        layout.setAlignment(Pos.CENTER);
+        layout.setPadding(new Insets(15, 15, 15, 15));
+
+        Scene sc = new Scene(layout);
+        window.setScene(sc);
+        window.showAndWait();
+
+        return answer;
+    }
+
     private static void handleContinue(Stage window)
     {
         response = true;
@@ -77,6 +110,12 @@ public class Alert
     private static void handleCancel(Stage window)
     {
         response = false;
+        window.close();
+    }
+
+    private static void handleSave(Stage window)
+    {
+        answer = userAnswer.getText();
         window.close();
     }
 }

--- a/src/main/java/app/view/mapBuilder/StartMenu.java
+++ b/src/main/java/app/view/mapBuilder/StartMenu.java
@@ -44,7 +44,9 @@ public class StartMenu extends BorderPane
         {
             Settings settings = settingsPane.getSettings();
             furniturePane.getSettings(settings);
-            FileManager.saveSettings(settings, settings.getName());
+            String fileName = Alert.answerAlert("Name of File", "Enter the Name of the file you wish to create.");
+            settings.setName(fileName);
+            FileManager.saveSettings(settings, fileName);
             Alert.displayAlert("Done!", "The map file was successfully created.");
         }
         else
@@ -59,8 +61,9 @@ public class StartMenu extends BorderPane
         {
             Settings settings = settingsPane.getSettings();
             furniturePane.getSettings(settings);
-            FileManager.saveSettings(settings, settings.getName());
-            String fileName = settings.getName();
+            String fileName = Alert.answerAlert("Name of File", "Enter the Name of the file you wish to create.");
+            settings.setName(fileName);
+            FileManager.saveSettings(settings, fileName);
             app.gotoSimulation(fileName);
         }
         else


### PR DESCRIPTION
The user is prompted to give a name to the file before it is created. Improving upon the messy way of trying to remember to do so on the settings panel before creating the map.

Closes #338 