### PR TITLE
removed TargetBoundaries from getBoundaries in Map

### DIFF
--- a/src/main/java/app/model/Map.java
+++ b/src/main/java/app/model/Map.java
@@ -145,11 +145,18 @@ public class Map
 
     public ArrayList<Boundary> getBoundaries()
     {
+        ArrayList<Furniture> filteredFurniture = (ArrayList<Furniture>) furniture.clone();
+        filterFurnitureType(filteredFurniture, FurnitureType.TARGET);
+
         ArrayList<Boundary> boundaries = new ArrayList<>();
-        furniture.forEach(e -> boundaries.addAll(e.getBoundaries()));
+        filteredFurniture.forEach(e -> boundaries.addAll(e.getBoundaries()));
         return boundaries;
     }
 
+    private void filterFurnitureType(ArrayList<Furniture> furn, FurnitureType type)
+    {
+        furn.removeIf(e -> e.getType() == type);
+    }
 
     public void drawIndicatorBoxes(GraphicsContext gc)
     {


### PR DESCRIPTION
intruders (and guards) weren't able to enter the targetArea because of boundaries, now they can